### PR TITLE
Fixing references calculation to be robust to sorting issues

### DIFF
--- a/featuresets/Ppron.md
+++ b/featuresets/Ppron.md
@@ -15,6 +15,7 @@ Our approach prioritizes the paradigm of personal pronouns, as [Cysouw (2003: 31
 Aspects of personal pronoun paradigms have been observed to exhibit various areal tendencies.
 
 [Bickel and Nichos (2005)](Source#cldf:bickel2005inclusive) found that the inclusive/exclusive distinction is
+
 - more often present in the Circum-Pacific area (47%) than in the rest of the world (21%),
 - more often present in Meso & South America (54%) than in North America (29%),
 - much less frequent in Europe and North Asia (17%) than in the rest of the world (43%).
@@ -22,6 +23,7 @@ Aspects of personal pronoun paradigms have been observed to exhibit various area
 They also found a distributional difference between “Belhare” (1sg and 1excl are morphologically related) and “Chechen” (1sg and 1excl are morphologically unrelated) linguistic types ([Bickel and Nichos 2005](Source#cldf:bickel2005inclusive): 51). The two types are fairly evenly distributed within the Americas, but the Belhare type is the most frequent type elsewhere. Finally, they found that Minimal-Augmented systems occur most frequently in Australia (30%), followed by the Circum-Pacific area (10%); such a system is rare in the rest of the world (1%).
 
 According to [Cysouw (2003)](Source#cldf:cysouw2003paradigmatic), certain types show areal distributions, for example:
+
 - the Sinhalese type (no inclusive/exclusive distinction, no 3sg vs. 3pl) is common in North America and in the languages of Papua New Guinea (but with zero marked 3rd person);
 - the Maranao type (minimal-augmented, with number distinction throughout the 4 persons) occurs in non-Pama-Nyungan languages from Australia, in a few Papuan languages, in a few languages in North America (mostly in West California and Oregon), and in Nivkh \[gily1242\];
 - the Kwakiutl type (inclusive/exclusive distinction, singular vs. plural opposition only in the 1st person) is attested throughout the world, but interestingly, never widespread within a linguistic family.
@@ -30,6 +32,7 @@ Last but not least, according to [Krasnoukhova (2022)](Source#cldf:krasnoukhova2
 
 ## How?
 We consider pronouns to be elements that cannot co-occur with a noun phrase indexing the same referent. If a language has several pronoun series, we document pronouns:
+
 - in assertive, intransitive main clauses;
 - which encode the S argument of active verbs (e.g. ‘to run’), which is typically subject-like, in cases of split intransitivity;
 - which keep track of topic rather than focus on or emphasize a referent (as in Nanti \[nant1250\], see [the example in Ppron-05](#yes-nanti-nant1250-arawakan-peru)).
@@ -229,6 +232,7 @@ For the 1st person plural pronouns, there are three possible contexts that can b
 ---
 
 **Dual note**: In some grammars, forms that are actually inclusive (1+2(+3)) may be erroneously referred to or described as “dual”, since their most common reference is the minimal inclusive group (1+2) which consists of two people. In such cases, it is usually telling that there is no other dual form in the language (i.e. there are no dual forms for 2nd or 3rd person). However, it is possible although rare that languages do have a real dual form only in the 1st person. In such cases this dual 1st person form is attested in both 1+2 and 1+3 contexts, as long as only two people are involved. Therefore, when a single “dual” form is described in the grammar, one needs to carefully search for examples to establish if it is really a dual form or if it is in fact an inclusive form. There are two possible diagnostic contexts: 
+
 - 1+3 with only two people: If the “dual” form in question is a real dual it will be used in this context, while an inclusive will not.
 - 1+2+3: If the “dual” form in question is a real dual it will not be used in this context, while an inclusive will.
 
@@ -445,7 +449,7 @@ Table 8: Daga pronouns
 Neither *yatse* '1du' nor *ekwana* '1pl' seem related to the endonym Cavineña, whose origin is unknown ([Guillaume 2008](Source#cldf:guillaume2008cavinena): 1). It might originate from “Caviña”, the name of one of the two moieties in the neighboring sister language Araona. 
 
 #### inclusive: Ese Ejja \[esee1248\] (Pano-Tacanan; Bolivia, Peru)
-Ese Ejja \[eseʔeχa\] is an endonym and it resembles the form *ese(a)* '1incl'. A possible etymology is from *ese(a)'dejja* \[eseɖeχa\] 'we people', where the dental implosive is realized as a glottal stop: ese'dejja &gt; Ese Ejja ([Vuillermet 2012](Source#cldf:vuillermet2012eseejja): 45-46).
+Ese Ejja [eseʔeχa] is an endonym and it resembles the form *ese(a)* '1incl'. A possible etymology is from *ese(a)'dejja* \[eseɖeχa\] 'we people', where the dental implosive is realized as a glottal stop: ese'dejja &gt; Ese Ejja ([Vuillermet 2012](Source#cldf:vuillermet2012eseejja): 45-46).
 
 ### [](ParameterTable#cldf:Ppron-05)
 &emsp;**{ NA | yes | no }**

--- a/processing-scripts/alignment/alignment_references.py
+++ b/processing-scripts/alignment/alignment_references.py
@@ -80,22 +80,18 @@ def yield_from_cldf(
     type: str,
     errors: SimpleContainer,
 ):
-    current_language = ""
-    language_rows = []
     selector_for_this_type = TYPE_TO_SELECTOR_TYPE[type]
     # load languages
     glotto_code_to_language = {}
+    glottocode_to_context_rows = {}
     for language in dataset["languages.csv"]:
         glotto_code_to_language[language[E_GLOT]] = language["Name"]
+        glottocode_to_context_rows[language[E_GLOT]] = []
     # load selectors.csv; selector_id : row
     selector_id_to_selector_row = {}
     for selector_row in dataset["selectors.csv"]:
         selector_id_to_selector_row[selector_row["ID"]] = selector_row
-    # set first language glottocode
-    for row in dataset["contexts.csv"]:
-        current_language = row[E_GLOT]
-        break
-    # yielding data, adding fields from languages and selectors
+    # load contexts.csv; get rows
     for row in dataset["contexts.csv"]:
         try:
             row[E_LAN] = glotto_code_to_language[row[E_GLOT]]
@@ -115,33 +111,21 @@ def yield_from_cldf(
         # add data from selectors.csv
         selector_id = row[E_SEL_ID]
         # some selector ids are None, warn and skip
-        # try:
         selector_row = selector_id_to_selector_row[selector_id]
         # we are not calculating non-person based alignments: Ignore gender/other/number -- note there may be more combinations in the future
         if selector_row[E_FEAT] == "other" or selector_row[E_FEAT] == "gender" or selector_row[E_FEAT] == "number" or selector_row[E_FEAT] == "number" or selector_row[E_FEAT] == "number+gender":
             continue
         for header in [E_SEL, E_SEL_TYPE, E_OV, E_FEAT]:
             row[header] = selector_row[header]
-        if current_language != row[E_GLOT]:
-            # yield only rows belonging to that type
-            dummy = [
-                l
-                for l in language_rows
-                if l[E_SEL_TYPE] in selector_for_this_type  # or l[E_REF] == "any"
-            ]
-            yield dummy
-            language_rows = []
-            language_rows.append(row)
-            current_language = row[E_GLOT]
-        else:
-            language_rows.append(row)
-    # once we exit the for loop, we still need to return the last language
-    dummy = [
-        l
-        for l in language_rows
-        if l[E_SEL_TYPE] in selector_for_this_type  # or l[E_REF] == "any"
-    ]
-    yield dummy
+        glottocode_to_context_rows[row[E_GLOT]].append(row)
+    # yielding data, adding fields from languages and selectors
+    for glot in glotto_code_to_language.keys():
+        dummy = [
+            l
+            for l in glottocode_to_context_rows[glot]
+            if l[E_SEL_TYPE] in selector_for_this_type
+        ]
+        yield dummy
 
 
 def write_intermediate_csv(


### PR DESCRIPTION
I have changed the functioning of alignment_refereences.py so that it first collects all the contexts rows according to language. This means it is now robust to different orderings in the underlying data. Closes #127.

I confirmed this did not change anything in the references calculations.